### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 env:
   POM_XML_DIRECTORY: '.'  # set this to the directory which contains pom.xml file
   AZURE_FUNCTIONAPP_NAME: 'timezone-conversion-java'


### PR DESCRIPTION
Potential fix for [https://github.com/anishi1222/timezone-conversion-java/security/code-scanning/1](https://github.com/anishi1222/timezone-conversion-java/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root (best here since there is one job) to constrain `GITHUB_TOKEN` for all jobs unless overridden.  
For this workflow, the minimal and appropriate permission is:

- `contents: read`

This supports checkout/read operations while preventing unnecessary write scopes.  
Edit `.github/workflows/maven-publish.yml` by inserting `permissions:` after the `on:` trigger section and before `env:`. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
